### PR TITLE
Fix notification fallback actions

### DIFF
--- a/app/src/main/java/com/example/badger/AlarmReceiver.kt
+++ b/app/src/main/java/com/example/badger/AlarmReceiver.kt
@@ -75,6 +75,10 @@ class AlarmReceiver : BroadcastReceiver() {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .setShortcutId(SHORTCUT_ID)         // must match your shortcut XML
+            // When the bubble disappears, tapping the notification should reopen
+            // the reschedule screen. Setting a content intent keeps the
+            // notification interactive on older Android versions.
+            .setContentIntent(bubbleIntent)
             .addPerson(person)                  // conversation style
             .setBubbleMetadata(bubbleData)      // enable bubble overlay
             .setAutoCancel(true)


### PR DESCRIPTION
## Summary
- keep notifications interactive when a bubble times out

## Testing
- `./gradlew test --console=plain` *(fails: HTTP 403 when downloading gradle)*

------
https://chatgpt.com/codex/tasks/task_e_687168339e188331ad13ab4f8d44231a